### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/pkg/feature_installer/helmrelease_create.go
+++ b/pkg/feature_installer/helmrelease_create.go
@@ -78,7 +78,7 @@ func CreateHelmRelease(featureName, featureSetName, ns string, profile *profilev
 	}
 
 	if len(profile.Spec.Features[featureName].ValuesFrom) > 0 {
-		valuesFrom := make([]fluxhelm.ValuesReference, 0)
+		valuesFrom := make([]fluxhelm.ValuesReference, 0, len(profile.Spec.Features[featureName].ValuesFrom))
 		for _, vf := range profile.Spec.Features[featureName].ValuesFrom {
 			valuesFrom = append(valuesFrom, fluxhelm.ValuesReference{
 				Kind:      vf.Kind,


### PR DESCRIPTION
- Enable bodyclose and prealloc linters
- Move exclude-files/exclude-dirs to linters.exclusions.paths (golangci-lint
  v2 location) and fix over-escaped regex generated.*\\.go -> generated.*\.go
- Switch formatter from gofmt to gofumpt and drop the interface{} -> any
  rewrite rule (gofumpt is a stricter superset)
- Preallocate valuesFrom slice to satisfy prealloc

Signed-off-by: Tamal Saha <tamal@appscode.com>
