### PR TITLE
Wait for cluster upgrades across requeues, and honor profile charts

### DIFF
--- a/pkg/cluster_upgrade/upgrader.go
+++ b/pkg/cluster_upgrade/upgrader.go
@@ -63,12 +63,37 @@ type upgradeTarget struct {
 	MinGeneration int64 `json:"minGeneration"`
 }
 
-// newUpgradeTarget derives the generation that marks oldObject as replaced by
-// newObject. A rewrite that changes nothing does not bump the generation on the
-// spoke, so waiting for a higher one would hang until the timeout.
-func newUpgradeTarget(mw *workv1.ManifestWork, hr *fluxhelm.HelmRelease, oldObject, newObject map[string]any) upgradeTarget {
+// specChanged reports whether the HelmRelease spec this upgrade writes differs
+// from the one oldManifest already carries. Only the spec is compared: a typed
+// round trip also rewrites hub-side noise (an empty `status`, say) that the work
+// agent never propagates, so a whole-manifest comparison reports a change the
+// spoke will not act on.
+func specChanged(oldManifest workv1.Manifest, newSpec fluxhelm.HelmReleaseSpec) (bool, error) {
+	var oldHR fluxhelm.HelmRelease
+	if err := utils.Copy(oldManifest, &oldHR); err != nil {
+		return false, err
+	}
+
+	// Through maps rather than the structs: spec.values is raw JSON, so equal
+	// values can still differ byte for byte.
+	oldMap, newMap := map[string]any{}, map[string]any{}
+	if err := utils.Copy(oldHR.Spec, &oldMap); err != nil {
+		return false, err
+	}
+	if err := utils.Copy(newSpec, &newMap); err != nil {
+		return false, err
+	}
+
+	return !reflect.DeepEqual(oldMap, newMap), nil
+}
+
+// newUpgradeTarget derives the generation that marks the HelmRelease as carrying
+// the spec this upgrade wrote. A rewrite that changes nothing does not bump the
+// generation on the spoke, so waiting for a higher one would hang until the
+// timeout.
+func newUpgradeTarget(mw *workv1.ManifestWork, hr *fluxhelm.HelmRelease, changed bool) upgradeTarget {
 	minGeneration := helmReleaseGeneration(mw, hr.Namespace, hr.Name)
-	if !reflect.DeepEqual(oldObject, newObject) {
+	if changed {
 		minGeneration++
 	}
 
@@ -207,22 +232,22 @@ func applyUpgrade(ctx context.Context, kc client.Client, profileBinding *profile
 				hr.Spec.Values = &apiextensionsJSON
 			}
 
+			changed, err := specChanged(m, hr.Spec)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
 			manifest := workv1.Manifest{}
 			if err = utils.Copy(hr, &manifest); err != nil {
 				return ctrl.Result{}, err
 			}
 
-			newObject := map[string]any{}
-			if err = utils.Copy(manifest, &newObject); err != nil {
-				return ctrl.Result{}, err
-			}
-
 			mw.Spec.Workload.Manifests[i] = manifest
 			configMap.Data[hr.Name] = string(metav1.ConditionFalse)
-			upgradeTargets = append(upgradeTargets, newUpgradeTarget(&mw, &hr, object, newObject))
+			upgradeTargets = append(upgradeTargets, newUpgradeTarget(&mw, &hr, changed))
 			ensureHelmReleaseFeedbackRules(&mw, hr.Namespace, hr.Name)
 
-			_, err := cu.CreateOrPatch(ctx, kc, &mw, func(obj client.Object, createOp bool) client.Object {
+			_, err = cu.CreateOrPatch(ctx, kc, &mw, func(obj client.Object, createOp bool) client.Object {
 				in := obj.(*workv1.ManifestWork)
 				in.Spec = mw.Spec
 				return in
@@ -337,19 +362,19 @@ func applyUpgrade(ctx context.Context, kc client.Client, profileBinding *profile
 			if hr.Spec.Install != nil {
 				hr.Spec.Install.CreateNamespace = feature.Spec.Chart.CreateNamespace
 			}
+			changed, err := specChanged(m, hr.Spec)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
 			manifest := workv1.Manifest{}
 			if err = utils.Copy(hr, &manifest); err != nil {
 				return ctrl.Result{}, err
 			}
 
-			newObject := map[string]any{}
-			if err = utils.Copy(manifest, &newObject); err != nil {
-				return ctrl.Result{}, err
-			}
-
 			mwList.Items[i].Spec.Workload.Manifests[j] = manifest
 			configMap.Data[hr.Name] = string(metav1.ConditionFalse)
-			upgradeTargets = append(upgradeTargets, newUpgradeTarget(&mwList.Items[i], &hr, object, newObject))
+			upgradeTargets = append(upgradeTargets, newUpgradeTarget(&mwList.Items[i], &hr, changed))
 			ensureHelmReleaseFeedbackRules(&mwList.Items[i], hr.Namespace, hr.Name)
 		}
 		_, err := cu.CreateOrPatch(ctx, kc, &mwList.Items[i], func(obj client.Object, createOp bool) client.Object {

--- a/pkg/cluster_upgrade/upgrader.go
+++ b/pkg/cluster_upgrade/upgrader.go
@@ -63,6 +63,28 @@ type upgradeTarget struct {
 	MinGeneration int64 `json:"minGeneration"`
 }
 
+// pruneNulls drops null-valued keys, mirroring what a JSON merge patch does to
+// the document it carries. Without it a null in spec.values makes every
+// comparison against the stored manifest report a change that can never be
+// written away.
+func pruneNulls(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if child == nil {
+				delete(typed, key)
+				continue
+			}
+			typed[key] = pruneNulls(child)
+		}
+	case []any:
+		for i, child := range typed {
+			typed[i] = pruneNulls(child)
+		}
+	}
+	return value
+}
+
 // specChanged reports whether the HelmRelease spec this upgrade writes differs
 // from the one oldManifest already carries. Only the spec is compared: a typed
 // round trip also rewrites hub-side noise (an empty `status`, say) that the work
@@ -84,7 +106,7 @@ func specChanged(oldManifest workv1.Manifest, newSpec fluxhelm.HelmReleaseSpec) 
 		return false, err
 	}
 
-	return !reflect.DeepEqual(oldMap, newMap), nil
+	return !reflect.DeepEqual(pruneNulls(oldMap), pruneNulls(newMap)), nil
 }
 
 // newUpgradeTarget derives the generation that marks the HelmRelease as carrying

--- a/pkg/cluster_upgrade/upgrader.go
+++ b/pkg/cluster_upgrade/upgrader.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	profilev1alpha1 "github.com/kluster-manager/cluster-profile/apis/profile/v1alpha1"
+	"github.com/kluster-manager/cluster-profile/pkg/common"
 	"github.com/kluster-manager/cluster-profile/pkg/feature_installer"
 	"github.com/kluster-manager/cluster-profile/pkg/utils"
 
@@ -39,6 +40,7 @@ import (
 	"kubepack.dev/lib-helm/pkg/repo"
 	"kubepack.dev/lib-helm/pkg/values"
 	workv1 "open-cluster-management.io/api/work/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	klog "sigs.k8s.io/controller-runtime/pkg/log"
 	releasesapi "x-helm.dev/apimachinery/apis/releases/v1alpha1"
@@ -49,14 +51,16 @@ const (
 	helmReleaseReadyTimeout      = 30 * time.Minute
 )
 
+// upgradeTarget is persisted on the upgrader ConfigMap between reconciles, so the
+// field names are part of that on-disk format.
 type upgradeTarget struct {
-	manifestWorkNamespace string
-	manifestWorkName      string
-	helmReleaseNamespace  string
-	helmReleaseName       string
-	// minGeneration is the spoke-side HelmRelease generation that proves the spec
+	ManifestWorkNamespace string `json:"manifestWorkNamespace"`
+	ManifestWorkName      string `json:"manifestWorkName"`
+	HelmReleaseNamespace  string `json:"helmReleaseNamespace"`
+	HelmReleaseName       string `json:"helmReleaseName"`
+	// MinGeneration is the spoke-side HelmRelease generation that proves the spec
 	// this upgrade wrote has reached the cluster.
-	minGeneration int64
+	MinGeneration int64 `json:"minGeneration"`
 }
 
 // newUpgradeTarget derives the generation that marks oldObject as replaced by
@@ -69,22 +73,60 @@ func newUpgradeTarget(mw *workv1.ManifestWork, hr *fluxhelm.HelmRelease, oldObje
 	}
 
 	return upgradeTarget{
-		manifestWorkNamespace: mw.Namespace,
-		manifestWorkName:      mw.Name,
-		helmReleaseNamespace:  hr.Namespace,
-		helmReleaseName:       hr.Name,
-		minGeneration:         minGeneration,
+		ManifestWorkNamespace: mw.Namespace,
+		ManifestWorkName:      mw.Name,
+		HelmReleaseNamespace:  hr.Namespace,
+		HelmReleaseName:       hr.Name,
+		MinGeneration:         minGeneration,
 	}
 }
 
-func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.ManagedClusterProfileBinding, profile *profilev1alpha1.ManagedClusterSetProfile, kc client.Client) error {
+// UpgradeCluster drives one step of an upgrade and returns when it needs to wait.
+// The wait for the spoke to converge is spread over requeues rather than held
+// inside a single reconcile: controller-runtime serializes per object key, so
+// blocking here would make the binding deaf to its own events -- including the
+// ManagedClusterSetProfile edit that fixes a failing HelmRelease.
+func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.ManagedClusterProfileBinding, profile *profilev1alpha1.ManagedClusterSetProfile, kc client.Client) (ctrl.Result, error) {
+	configMap, targets, err := findPendingUpgrade(ctx, kc, profileBinding)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if configMap != nil {
+		return observeUpgrade(ctx, kc, configMap, targets)
+	}
+	return applyUpgrade(ctx, kc, profileBinding, profile)
+}
+
+// observeUpgrade checks the targets of an already-applied upgrade. It costs a few
+// cached reads: no fake API server, no chart render.
+func observeUpgrade(ctx context.Context, kc client.Client, configMap *corev1.ConfigMap, targets []upgradeTarget) (ctrl.Result, error) {
+	pending, err := evaluateTargets(ctx, kc, targets, configMap)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if len(pending) == 0 {
+		return ctrl.Result{}, finishUpgrade(ctx, kc, configMap, nil)
+	}
+
+	if deadline := configMap.CreationTimestamp.Add(helmReleaseReadyTimeout); metav1.Now().After(deadline) {
+		// The targets left "false" never became ready, so the upgrade did not succeed.
+		return ctrl.Result{}, finishUpgrade(ctx, kc, configMap,
+			fmt.Errorf("timed out after %s waiting for HelmRelease(s) to become ready: %s", helmReleaseReadyTimeout, targetNames(pending)))
+	}
+
+	klog.FromContext(ctx).Info("Waiting for HelmRelease(s) to become ready", "pending", targetNames(pending))
+	return ctrl.Result{RequeueAfter: helmReleaseReadyPollInterval}, nil
+}
+
+func applyUpgrade(ctx context.Context, kc client.Client, profileBinding *profilev1alpha1.ManagedClusterProfileBinding, profile *profilev1alpha1.ManagedClusterSetProfile) (ctrl.Result, error) {
 	logger := klog.FromContext(ctx)
 	logger.Info(fmt.Sprintf("Upgrading Cluster: %s", profileBinding.Namespace))
 
 	var fakeServer *feature_installer.FakeServer
 	var err error
 	if fakeServer, err = feature_installer.StartFakeApiServerAndApplyBaseManifestWorkReplicaSets(ctx, kc, profileBinding); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	defer func() {
@@ -101,35 +143,35 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 
 	var overrideValues map[string]any
 	if profileBinding.Spec.Features == nil || profileBinding.Spec.Features[hub.ChartOpscenterFeatures].Values == nil {
-		return errors.New("no values found in profileBinding")
+		return ctrl.Result{}, errors.New("no values found in profileBinding")
 	}
 	if err := json.Unmarshal(profileBinding.Spec.Features[hub.ChartOpscenterFeatures].Values.Raw, &overrideValues); err != nil {
-		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}
 
 	if overrideValues, err = InstallOpscenterFeaturesOnFakeServer(fakeServer, overrideValues, &profileBinding.Spec.ClusterMetadata, &chartRef); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	if err := feature_installer.RegisterRequiredCRDs(fakeServer, profileBinding); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	defaultValues, err := feature_installer.GetDefaultValues(repo.NewRegistry(fakeServer.FakeClient, repo.DefaultDiskCache()), chartRef)
 	if err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	mergedValues := values.MergeMaps(defaultValues, overrideValues)
 
 	var mw workv1.ManifestWork
 	if err := kc.Get(ctx, types.NamespacedName{Name: "opscenter-core", Namespace: profileBinding.GetNamespace()}, &mw); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	configMap, err := createConfigMapInSpokeClusterNamespace(ctx, kc, profileBinding.Spec.OpscenterFeaturesVersion, profileBinding.Namespace)
 	if err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	var upgradeTargets []upgradeTarget
@@ -137,42 +179,42 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 	for i, m := range mw.Spec.Workload.Manifests {
 		object := map[string]any{}
 		if err = utils.Copy(m, &object); err != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 
 		_, name, _, err := feature_installer.GetKindNameNamespace(object)
 		if err != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 
 		if name == hub.ChartOpscenterFeatures {
 			hr := fluxhelm.HelmRelease{}
 			if err = utils.Copy(m, &hr); err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 
 			hr.Spec.Chart.Spec.Version = profileBinding.Spec.OpscenterFeaturesVersion
 			if mergedValues != nil {
 				jsonData, err := json.Marshal(mergedValues)
 				if err != nil {
-					return err
+					return ctrl.Result{}, err
 				}
 
 				var apiextensionsJSON v1.JSON
 				if err := json.Unmarshal(jsonData, &apiextensionsJSON); err != nil {
-					return err
+					return ctrl.Result{}, err
 				}
 				hr.Spec.Values = &apiextensionsJSON
 			}
 
 			manifest := workv1.Manifest{}
 			if err = utils.Copy(hr, &manifest); err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 
 			newObject := map[string]any{}
 			if err = utils.Copy(manifest, &newObject); err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 
 			mw.Spec.Workload.Manifests[i] = manifest
@@ -186,7 +228,7 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 				return in
 			})
 			if err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 
 			_, err = cu.CreateOrPatch(ctx, kc, configMap, func(obj client.Object, createOp bool) client.Object {
@@ -195,7 +237,7 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 				return in
 			})
 			if err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 			break
 		}
@@ -203,7 +245,7 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 
 	var mwList workv1.ManifestWorkList
 	if err := kc.List(ctx, &mwList, client.InNamespace(profileBinding.Namespace)); err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	for i, mw := range mwList.Items {
@@ -214,12 +256,12 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 		for j, m := range mwList.Items[i].Spec.Workload.Manifests {
 			object := map[string]any{}
 			if err = utils.Copy(m, &object); err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 
 			kind, name, _, err := feature_installer.GetKindNameNamespace(object)
 			if err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 
 			if kind != fluxhelm.HelmReleaseKind || name == hub.ChartOpscenterFeatures {
@@ -228,7 +270,7 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 
 			hr := fluxhelm.HelmRelease{}
 			if err = utils.Copy(m, &hr); err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 			if label, exists := hr.Labels["app.kubernetes.io/component"]; !exists || label != hr.Name {
 				continue
@@ -240,7 +282,7 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 				if _, exist := profileBinding.Spec.Features[hr.Name]; exist {
 					if profileBinding.Spec.Features[hr.Name].Values != nil {
 						if err = json.Unmarshal(profileBinding.Spec.Features[hr.Name].Values.Raw, &currValues); err != nil {
-							return err
+							return ctrl.Result{}, err
 						}
 						skipManagedClusterSetProfileValues = true
 					}
@@ -251,19 +293,26 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 				if profile.Spec.Features[hr.Name].Values != nil {
 					err = json.Unmarshal(profile.Spec.Features[hr.Name].Values.Raw, &currValues)
 					if err != nil {
-						return err
+						return ctrl.Result{}, err
 					}
 				}
 			}
 
 			var feature uiapi.Feature
 			if err := fakeServer.FakeClient.Get(ctx, types.NamespacedName{Name: hr.Name}, &feature); err != nil {
-				return err
+				return ctrl.Result{}, err
+			}
+			// Same precedence as the non-upgrade path (GetFeatureSetValues): an
+			// explicit chart in the profile wins over the one the opscenter-features
+			// chart ships, so a profile edit is how an operator pins or relocates a
+			// feature during an upgrade too.
+			if featureSpec, found := profile.Spec.Features[feature.Name]; found && featureSpec.Chart.Name != "" {
+				feature.Spec.Chart = featureSpec.Chart
 			}
 			var featureValues map[string]any
 			if feature.Spec.Values != nil {
 				if err := json.Unmarshal(feature.Spec.Values.Raw, &featureValues); err != nil {
-					return err
+					return ctrl.Result{}, err
 				}
 			}
 
@@ -271,24 +320,31 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 			if finalValues != nil {
 				jsonData, err := json.Marshal(finalValues)
 				if err != nil {
-					return err
+					return ctrl.Result{}, err
 				}
 
 				var apiextensionsJSON v1.JSON
 				if err := json.Unmarshal(jsonData, &apiextensionsJSON); err != nil {
-					return err
+					return ctrl.Result{}, err
 				}
 				hr.Spec.Values = &apiextensionsJSON
 			}
 			hr.Spec.Chart.Spec.Version = feature.Spec.Chart.Version
+			if feature.Spec.Chart.Namespace != "" {
+				hr.Spec.TargetNamespace = feature.Spec.Chart.Namespace
+				hr.Spec.StorageNamespace = feature.Spec.Chart.Namespace
+			}
+			if hr.Spec.Install != nil {
+				hr.Spec.Install.CreateNamespace = feature.Spec.Chart.CreateNamespace
+			}
 			manifest := workv1.Manifest{}
 			if err = utils.Copy(hr, &manifest); err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 
 			newObject := map[string]any{}
 			if err = utils.Copy(manifest, &newObject); err != nil {
-				return err
+				return ctrl.Result{}, err
 			}
 
 			mwList.Items[i].Spec.Workload.Manifests[j] = manifest
@@ -302,7 +358,7 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 			return in
 		})
 		if err != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 
 		_, err = cu.CreateOrPatch(ctx, kc, configMap, func(obj client.Object, createOp bool) client.Object {
@@ -311,19 +367,17 @@ func UpgradeCluster(ctx context.Context, profileBinding *profilev1alpha1.Managed
 			return in
 		})
 		if err != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 	}
 
-	waitErr := waitForHelmReleasesReady(ctx, kc, upgradeTargets, configMap, helmReleaseReadyPollInterval, helmReleaseReadyTimeout)
-	if waitErr != nil && ctx.Err() != nil {
-		// Interrupted, so the upgrade job never finished: leave the ConfigMap pending.
-		return waitErr
+	if len(upgradeTargets) == 0 {
+		return ctrl.Result{}, finishUpgrade(ctx, kc, configMap, nil)
 	}
 
-	// "completed" only tells the UI that the upgrade job is done; whether it
-	// succeeded is read from the per-feature values, so it is set even when some
-	// features never became ready.
-	configMap.Data["status"] = "completed"
-	return errors.Join(waitErr, patchConfigMapData(ctx, kc, configMap))
+	if err := recordPendingUpgrade(ctx, kc, configMap, upgradeTargets, profileBinding.Annotations[common.UpgradeAnnotation]); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: helmReleaseReadyPollInterval}, nil
 }

--- a/pkg/cluster_upgrade/upgrader_helper.go
+++ b/pkg/cluster_upgrade/upgrader_helper.go
@@ -18,23 +18,23 @@ package cluster_upgrade
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"slices"
 	"strings"
-	"time"
 
+	profilev1alpha1 "github.com/kluster-manager/cluster-profile/apis/profile/v1alpha1"
 	"github.com/kluster-manager/cluster-profile/pkg/common"
 	"github.com/kluster-manager/cluster-profile/pkg/feature_installer"
 	"github.com/kluster-manager/cluster-profile/pkg/utils"
 
 	fluxhelm "github.com/fluxcd/helm-controller/api/v2"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	kmapi "kmodules.xyz/client-go/api/v1"
 	cu "kmodules.xyz/client-go/client"
@@ -84,11 +84,11 @@ func helmReleaseGeneration(mw *workv1.ManifestWork, hrNamespace, hrName string) 
 // applied and Ready *for the spec this upgrade wrote*. Feedback values lag the
 // spec patch and flux keeps Ready=True until it notices the new spec, so a Ready
 // feedback alone can still describe the pre-upgrade release. The generation
-// feedback pins it down: it must have reached target.minGeneration (proving the
+// feedback pins it down: it must have reached target.MinGeneration (proving the
 // object is the one we wrote) and flux must have observed it (proving flux is
 // done with it, not about to start).
 func helmReleaseReady(mw *workv1.ManifestWork, target upgradeTarget) bool {
-	values, applied := helmReleaseFeedback(mw, target.helmReleaseNamespace, target.helmReleaseName)
+	values, applied := helmReleaseFeedback(mw, target.HelmReleaseNamespace, target.HelmReleaseName)
 	if !applied {
 		return false
 	}
@@ -98,7 +98,7 @@ func helmReleaseReady(mw *workv1.ManifestWork, target upgradeTarget) bool {
 	}
 
 	generation, ok := feedbackInt(values, common.HelmReleaseGenerationFeedback)
-	if !ok || generation < target.minGeneration {
+	if !ok || generation < target.MinGeneration {
 		return false
 	}
 
@@ -155,61 +155,122 @@ func ensureHelmReleaseFeedbackRules(mw *workv1.ManifestWork, hrNamespace, hrName
 	})
 }
 
-// waitForHelmReleasesReady marks each target ready in configMap as it becomes
-// ready, until none are left or timeout elapses. A timeout is an error: the
-// targets left "false" never became ready, so the upgrade did not succeed.
-func waitForHelmReleasesReady(ctx context.Context, kc client.Client, targets []upgradeTarget, configMap *corev1.ConfigMap, interval, timeout time.Duration) error {
-	pending := slices.Clone(targets)
+// evaluateTargets marks every target that has become ready in configMap and
+// returns the ones still pending. A ManifestWork read error keeps its target
+// pending rather than failing the upgrade: the specs are already on their way to
+// the spoke, so the only sane response is to look again next tick.
+func evaluateTargets(ctx context.Context, kc client.Client, targets []upgradeTarget, configMap *corev1.ConfigMap) ([]upgradeTarget, error) {
+	logger := klog.FromContext(ctx)
+	pending := make([]upgradeTarget, 0, len(targets))
+	becameReady := false
 
-	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
-		logger := klog.FromContext(ctx)
-		notReady := make([]upgradeTarget, 0, len(pending))
-		becameReady := false
+	for _, target := range targets {
+		var mw workv1.ManifestWork
+		if err := kc.Get(ctx, types.NamespacedName{Name: target.ManifestWorkName, Namespace: target.ManifestWorkNamespace}, &mw); err != nil {
+			logger.Error(err, "failed to read ManifestWork while waiting for HelmRelease", "manifestWork", klog.KRef(target.ManifestWorkNamespace, target.ManifestWorkName))
+			pending = append(pending, target)
+			continue
+		}
 
-		for _, target := range pending {
-			var mw workv1.ManifestWork
-			if err := kc.Get(ctx, types.NamespacedName{Name: target.manifestWorkName, Namespace: target.manifestWorkNamespace}, &mw); err != nil {
-				// The upgrade is already in flight on the spoke; a read error must not
-				// abort it, so keep the target pending and retry on the next tick.
-				logger.Error(err, "failed to read ManifestWork while waiting for HelmRelease", "manifestWork", klog.KRef(target.manifestWorkNamespace, target.manifestWorkName))
-				notReady = append(notReady, target)
-				continue
-			}
-
-			if helmReleaseReady(&mw, target) {
-				configMap.Data[target.helmReleaseName] = string(metav1.ConditionTrue)
+		if helmReleaseReady(&mw, target) {
+			if configMap.Data[target.HelmReleaseName] != string(metav1.ConditionTrue) {
+				configMap.Data[target.HelmReleaseName] = string(metav1.ConditionTrue)
 				becameReady = true
-			} else {
-				notReady = append(notReady, target)
 			}
+		} else {
+			pending = append(pending, target)
+		}
+	}
+
+	if becameReady {
+		if err := patchConfigMapData(ctx, kc, configMap); err != nil {
+			return nil, fmt.Errorf("failed to mark HelmRelease(s) ready in upgrader ConfigMap %s: %w", client.ObjectKeyFromObject(configMap), err)
+		}
+	}
+
+	return pending, nil
+}
+
+func targetNames(targets []upgradeTarget) string {
+	names := make([]string, 0, len(targets))
+	for _, target := range targets {
+		names = append(names, fmt.Sprintf("%s/%s", target.HelmReleaseNamespace, target.HelmReleaseName))
+	}
+	return strings.Join(names, ", ")
+}
+
+// findPendingUpgrade returns the ConfigMap and targets of an upgrade this
+// controller already applied and is still waiting on, or nil if there is none.
+// A ConfigMap without the targets annotation was written by an older build and
+// cannot be resumed, so it is reported as no pending upgrade; re-applying is
+// harmless because every patch is idempotent.
+func findPendingUpgrade(ctx context.Context, kc client.Client, profileBinding *profilev1alpha1.ManagedClusterProfileBinding) (*corev1.ConfigMap, []upgradeTarget, error) {
+	var configMaps corev1.ConfigMapList
+	if err := kc.List(ctx, &configMaps, client.InNamespace(profileBinding.Namespace), client.MatchingLabels{common.ACEUpgrader: "true"}); err != nil {
+		return nil, nil, err
+	}
+
+	for i := range configMaps.Items {
+		configMap := &configMaps.Items[i]
+		if configMap.Labels[common.ACEUpgraderVersion] != profileBinding.Spec.OpscenterFeaturesVersion ||
+			configMap.Data[common.UpgradeStatusKey] != common.UpgradeStatusPending ||
+			// A repeated force-upgrade at the same version is a new run, not a resume.
+			configMap.Annotations[common.UpgradeAnnotation] != profileBinding.Annotations[common.UpgradeAnnotation] {
+			continue
 		}
 
-		if becameReady {
-			if err := patchConfigMapData(ctx, kc, configMap); err != nil {
-				// pending is left untouched so the marks are re-applied next tick.
-				logger.Error(err, "failed to mark HelmRelease(s) ready in upgrader ConfigMap", "configMap", klog.KObj(configMap))
-				return false, nil
-			}
+		raw, ok := configMap.Annotations[common.UpgradeTargetsAnnotation]
+		if !ok {
+			continue
 		}
+		var targets []upgradeTarget
+		if err := json.Unmarshal([]byte(raw), &targets); err != nil {
+			return nil, nil, fmt.Errorf("failed to read upgrade targets from ConfigMap %s: %w", client.ObjectKeyFromObject(configMap), err)
+		}
+		return configMap, targets, nil
+	}
 
-		pending = notReady
+	return nil, nil, nil
+}
 
-		return len(pending) == 0, nil
-	})
+// recordPendingUpgrade stores what the observing reconciles need to resume the
+// wait without re-rendering the chart.
+func recordPendingUpgrade(ctx context.Context, kc client.Client, configMap *corev1.ConfigMap, targets []upgradeTarget, upgradeAt string) error {
+	raw, err := json.Marshal(targets)
 	if err != nil {
-		names := make([]string, 0, len(pending))
-		for _, target := range pending {
-			names = append(names, fmt.Sprintf("%s/%s", target.helmReleaseNamespace, target.helmReleaseName))
-		}
-		// wait.Interrupted is also true for a cancelled parent context, so ask the
-		// parent whether this was a shutdown rather than a real timeout.
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return fmt.Errorf("interrupted while waiting for HelmRelease(s) %s: %w", strings.Join(names, ", "), ctxErr)
-		}
-		if wait.Interrupted(err) {
-			return fmt.Errorf("timed out after %s waiting for HelmRelease(s) to become ready: %s", timeout, strings.Join(names, ", "))
-		}
 		return err
+	}
+	if configMap.Annotations == nil {
+		configMap.Annotations = make(map[string]string)
+	}
+	configMap.Annotations[common.UpgradeTargetsAnnotation] = string(raw)
+	if upgradeAt != "" {
+		configMap.Annotations[common.UpgradeAnnotation] = upgradeAt
+	}
+	return patchConfigMapData(ctx, kc, configMap)
+}
+
+// finishUpgrade closes out the run. "completed" only tells the UI that the
+// upgrade job is done; whether it succeeded is read from the per-feature values,
+// so it is set even when some features never became ready.
+func finishUpgrade(ctx context.Context, kc client.Client, configMap *corev1.ConfigMap, upgradeErr error) error {
+	configMap.Data[common.UpgradeStatusKey] = common.UpgradeStatusCompleted
+	delete(configMap.Annotations, common.UpgradeTargetsAnnotation)
+	return errors.Join(upgradeErr, patchConfigMapData(ctx, kc, configMap))
+}
+
+// deleteStaleUpgraderConfigMaps drops upgrader ConfigMaps left behind by earlier
+// runs, so the UI always has exactly one to read. Reaching this point means no
+// resumable run exists, so nothing here is still in use.
+func deleteStaleUpgraderConfigMaps(ctx context.Context, kc client.Client, clusterName string) error {
+	var configMaps corev1.ConfigMapList
+	if err := kc.List(ctx, &configMaps, client.InNamespace(clusterName), client.MatchingLabels{common.ACEUpgrader: "true"}); err != nil {
+		return err
+	}
+	for i := range configMaps.Items {
+		if err := kc.Delete(ctx, &configMaps.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
 	return nil
 }
@@ -218,17 +279,31 @@ func patchConfigMapData(ctx context.Context, kc client.Client, configMap *corev1
 	_, err := cu.CreateOrPatch(ctx, kc, configMap, func(obj client.Object, createOp bool) client.Object {
 		in := obj.(*corev1.ConfigMap)
 		in.Data = configMap.Data
+		// Merge rather than assign: only the upgrade bookkeeping is ours to set.
+		for k, v := range configMap.Annotations {
+			if in.Annotations == nil {
+				in.Annotations = make(map[string]string)
+			}
+			in.Annotations[k] = v
+		}
+		if _, ours := configMap.Annotations[common.UpgradeTargetsAnnotation]; !ours {
+			delete(in.Annotations, common.UpgradeTargetsAnnotation)
+		}
 		return in
 	})
 	return err
 }
 
 func createConfigMapInSpokeClusterNamespace(ctx context.Context, kc client.Client, ver, clusterName string) (*corev1.ConfigMap, error) {
+	if err := deleteStaleUpgraderConfigMaps(ctx, kc, clusterName); err != nil {
+		return nil, err
+	}
+
 	var err error
 	cmData := make(map[string]string)
 	cmData["opscenter-features"] = string(metav1.ConditionFalse)
 	cmData["version"] = ver
-	cmData["status"] = "pending"
+	cmData[common.UpgradeStatusKey] = common.UpgradeStatusPending
 
 	var mwList workv1.ManifestWorkList
 	if err := kc.List(ctx, &mwList, client.InNamespace(clusterName)); err != nil {

--- a/pkg/cluster_upgrade/upgrader_helper_test.go
+++ b/pkg/cluster_upgrade/upgrader_helper_test.go
@@ -1,0 +1,468 @@
+/*
+Copyright AppsCode Inc. and Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster_upgrade
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	profilev1alpha1 "github.com/kluster-manager/cluster-profile/apis/profile/v1alpha1"
+	"github.com/kluster-manager/cluster-profile/pkg/common"
+
+	fluxhelm "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// stubClient serves the reads these two functions make and records the writes.
+// client.Client is embedded unset on purpose: an unexpected call panics instead
+// of silently passing.
+type stubClient struct {
+	client.Client
+
+	manifestWorks map[string]*workv1.ManifestWork
+	manifestErr   map[string]error
+	configMaps    []corev1.ConfigMap
+	listErr       error
+	patchErr      error
+
+	listOpts []client.ListOption
+	patched  []*corev1.ConfigMap
+}
+
+func (c *stubClient) Scheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := workv1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	return scheme
+}
+
+func (c *stubClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	switch out := obj.(type) {
+	case *workv1.ManifestWork:
+		if err, found := c.manifestErr[key.String()]; found {
+			return err
+		}
+		mw, found := c.manifestWorks[key.String()]
+		if !found {
+			return apierrors.NewNotFound(schema.GroupResource{Resource: "manifestworks"}, key.Name)
+		}
+		mw.DeepCopyInto(out)
+		return nil
+	case *corev1.ConfigMap:
+		for i := range c.configMaps {
+			if client.ObjectKeyFromObject(&c.configMaps[i]) == key {
+				c.configMaps[i].DeepCopyInto(out)
+				return nil
+			}
+		}
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
+	}
+	panic("unexpected Get")
+}
+
+func (c *stubClient) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	c.listOpts = opts
+	if c.listErr != nil {
+		return c.listErr
+	}
+	out, ok := list.(*corev1.ConfigMapList)
+	if !ok {
+		panic("unexpected List")
+	}
+	out.Items = append(out.Items, c.configMaps...)
+	return nil
+}
+
+func (c *stubClient) Patch(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+	if c.patchErr != nil {
+		return c.patchErr
+	}
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		panic("unexpected Patch")
+	}
+	c.patched = append(c.patched, cm.DeepCopy())
+	return nil
+}
+
+func stringValue(name, value string) workv1.FeedbackValue {
+	return workv1.FeedbackValue{Name: name, Value: workv1.FieldValue{Type: workv1.String, String: &value}}
+}
+
+func intValue(name string, value int64) workv1.FeedbackValue {
+	return workv1.FeedbackValue{Name: name, Value: workv1.FieldValue{Type: workv1.Integer, Integer: &value}}
+}
+
+// manifestWork builds a ManifestWork whose status reports hrNamespace/hrName with
+// the given feedback. applied controls the Applied condition the work agent sets.
+func manifestWork(name, hrNamespace, hrName string, applied bool, values ...workv1.FeedbackValue) *workv1.ManifestWork {
+	status := metav1.ConditionFalse
+	if applied {
+		status = metav1.ConditionTrue
+	}
+	return &workv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "spoke"},
+		Status: workv1.ManifestWorkStatus{
+			ResourceStatus: workv1.ManifestResourceStatus{
+				Manifests: []workv1.ManifestCondition{
+					{
+						ResourceMeta:    workv1.ManifestResourceMeta{Kind: fluxhelm.HelmReleaseKind, Name: hrName, Namespace: hrNamespace},
+						StatusFeedbacks: workv1.StatusFeedbackResult{Values: values},
+						Conditions:      []metav1.Condition{{Type: workv1.ManifestApplied, Status: status, Reason: "test"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func readyFeedback(generation int64) []workv1.FeedbackValue {
+	return []workv1.FeedbackValue{
+		stringValue(common.HelmReleaseReadyFeedback, string(metav1.ConditionTrue)),
+		intValue(common.HelmReleaseGenerationFeedback, generation),
+		intValue(common.HelmReleaseObservedGenerationFeedback, generation),
+	}
+}
+
+func target(mwName, hrName string, minGeneration int64) upgradeTarget {
+	return upgradeTarget{
+		ManifestWorkNamespace: "spoke",
+		ManifestWorkName:      mwName,
+		HelmReleaseNamespace:  "kubeops",
+		HelmReleaseName:       hrName,
+		MinGeneration:         minGeneration,
+	}
+}
+
+func upgraderConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "features-upgrader-x", Namespace: "spoke"},
+		Data:       data,
+	}
+}
+
+func TestEvaluateTargets(t *testing.T) {
+	// A HelmRelease flux has not looked at yet: the spec we wrote reached the
+	// spoke (generation 2) but observedGeneration still describes the old release,
+	// so a Ready=True feedback must not count.
+	staleObserved := []workv1.FeedbackValue{
+		stringValue(common.HelmReleaseReadyFeedback, string(metav1.ConditionTrue)),
+		intValue(common.HelmReleaseGenerationFeedback, 2),
+		intValue(common.HelmReleaseObservedGenerationFeedback, 1),
+	}
+
+	cases := []struct {
+		name        string
+		targets     []upgradeTarget
+		works       map[string]*workv1.ManifestWork
+		workErrs    map[string]error
+		data        map[string]string
+		wantPending []string
+		wantMarked  map[string]string
+		wantPatches int
+	}{
+		{
+			name:        "ready target is marked and drops out",
+			targets:     []upgradeTarget{target("observability", "prom-label-proxy", 2)},
+			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "kubeops", "prom-label-proxy", true, readyFeedback(2)...)},
+			data:        map[string]string{"prom-label-proxy": string(metav1.ConditionFalse)},
+			wantMarked:  map[string]string{"prom-label-proxy": string(metav1.ConditionTrue)},
+			wantPatches: 1,
+		},
+		{
+			name:        "flux has not observed the new spec yet",
+			targets:     []upgradeTarget{target("observability", "tenant-operator", 2)},
+			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "kubeops", "tenant-operator", true, staleObserved...)},
+			data:        map[string]string{"tenant-operator": string(metav1.ConditionFalse)},
+			wantPending: []string{"tenant-operator"},
+			wantPatches: 0,
+		},
+		{
+			name:        "not applied on the spoke",
+			targets:     []upgradeTarget{target("observability", "tenant-operator", 2)},
+			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "kubeops", "tenant-operator", false, readyFeedback(2)...)},
+			data:        map[string]string{"tenant-operator": string(metav1.ConditionFalse)},
+			wantPending: []string{"tenant-operator"},
+			wantPatches: 0,
+		},
+		{
+			name:        "already marked ready is not patched again",
+			targets:     []upgradeTarget{target("observability", "prom-label-proxy", 2)},
+			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "kubeops", "prom-label-proxy", true, readyFeedback(2)...)},
+			data:        map[string]string{"prom-label-proxy": string(metav1.ConditionTrue)},
+			wantPatches: 0,
+		},
+		{
+			name:        "unreadable ManifestWork keeps its target pending",
+			targets:     []upgradeTarget{target("observability", "tenant-operator", 2)},
+			workErrs:    map[string]error{"spoke/observability": errors.New("boom")},
+			data:        map[string]string{"tenant-operator": string(metav1.ConditionFalse)},
+			wantPending: []string{"tenant-operator"},
+			wantPatches: 0,
+		},
+		{
+			name: "one ready, one pending across separate ManifestWorks",
+			targets: []upgradeTarget{
+				target("observability", "prom-label-proxy", 2),
+				target("core", "kube-ui-server", 3),
+			},
+			works: map[string]*workv1.ManifestWork{
+				"spoke/observability": manifestWork("observability", "kubeops", "prom-label-proxy", true, readyFeedback(2)...),
+				"spoke/core":          manifestWork("core", "kubeops", "kube-ui-server", true, readyFeedback(2)...),
+			},
+			data:        map[string]string{"prom-label-proxy": string(metav1.ConditionFalse), "kube-ui-server": string(metav1.ConditionFalse)},
+			wantPending: []string{"kube-ui-server"},
+			wantMarked:  map[string]string{"prom-label-proxy": string(metav1.ConditionTrue)},
+			wantPatches: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			configMap := upgraderConfigMap(tc.data)
+			kc := &stubClient{
+				manifestWorks: tc.works,
+				manifestErr:   tc.workErrs,
+				configMaps:    []corev1.ConfigMap{*configMap},
+			}
+
+			pending, err := evaluateTargets(context.Background(), kc, tc.targets, configMap)
+			if err != nil {
+				t.Fatalf("evaluateTargets: %v", err)
+			}
+
+			got := make([]string, 0, len(pending))
+			for _, p := range pending {
+				got = append(got, p.HelmReleaseName)
+			}
+			if len(got) != len(tc.wantPending) {
+				t.Fatalf("pending = %v, want %v", got, tc.wantPending)
+			}
+			for i := range got {
+				if got[i] != tc.wantPending[i] {
+					t.Fatalf("pending = %v, want %v", got, tc.wantPending)
+				}
+			}
+
+			for name, want := range tc.wantMarked {
+				if configMap.Data[name] != want {
+					t.Errorf("ConfigMap[%s] = %q, want %q", name, configMap.Data[name], want)
+				}
+			}
+			if len(kc.patched) != tc.wantPatches {
+				t.Errorf("patches = %d, want %d", len(kc.patched), tc.wantPatches)
+			}
+			if tc.wantPatches > 0 {
+				last := kc.patched[len(kc.patched)-1]
+				for name, want := range tc.wantMarked {
+					if last.Data[name] != want {
+						t.Errorf("patched ConfigMap[%s] = %q, want %q", name, last.Data[name], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluateTargetsPatchFailureIsReported(t *testing.T) {
+	configMap := upgraderConfigMap(map[string]string{"prom-label-proxy": string(metav1.ConditionFalse)})
+	kc := &stubClient{
+		manifestWorks: map[string]*workv1.ManifestWork{
+			"spoke/observability": manifestWork("observability", "kubeops", "prom-label-proxy", true, readyFeedback(2)...),
+		},
+		configMaps: []corev1.ConfigMap{*configMap},
+		patchErr:   errors.New("conflict"),
+	}
+
+	if _, err := evaluateTargets(context.Background(), kc, []upgradeTarget{target("observability", "prom-label-proxy", 2)}, configMap); err == nil {
+		t.Fatal("expected an error when the ConfigMap patch fails")
+	}
+}
+
+func pendingConfigMap(name, version, upgradeAt string, targets string, status string) corev1.ConfigMap {
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "spoke",
+			Labels: map[string]string{
+				common.ACEUpgrader:        "true",
+				common.ACEUpgraderVersion: version,
+			},
+			Annotations: map[string]string{},
+		},
+		Data: map[string]string{common.UpgradeStatusKey: status},
+	}
+	if targets != "" {
+		cm.Annotations[common.UpgradeTargetsAnnotation] = targets
+	}
+	if upgradeAt != "" {
+		cm.Annotations[common.UpgradeAnnotation] = upgradeAt
+	}
+	return cm
+}
+
+func profileBinding(version, upgradeAt string) *profilev1alpha1.ManagedClusterProfileBinding {
+	pb := &profilev1alpha1.ManagedClusterProfileBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "spoke", Namespace: "spoke"},
+		Spec: profilev1alpha1.ManagedClusterProfileBindingSpec{
+			OpscenterFeaturesVersion: version,
+		},
+	}
+	if upgradeAt != "" {
+		pb.Annotations = map[string]string{common.UpgradeAnnotation: upgradeAt}
+	}
+	return pb
+}
+
+const oneTarget = `[{"manifestWorkNamespace":"spoke","manifestWorkName":"observability","helmReleaseNamespace":"kubeops","helmReleaseName":"prom-label-proxy","minGeneration":2}]`
+
+func TestFindPendingUpgrade(t *testing.T) {
+	cases := []struct {
+		name       string
+		configMaps []corev1.ConfigMap
+		binding    *profilev1alpha1.ManagedClusterProfileBinding
+		wantFound  string
+	}{
+		{
+			name:       "resumes a pending run for this version",
+			configMaps: []corev1.ConfigMap{pendingConfigMap("cm-a", "v1", "", oneTarget, common.UpgradeStatusPending)},
+			binding:    profileBinding("v1", ""),
+			wantFound:  "cm-a",
+		},
+		{
+			name:       "ignores a run for another version",
+			configMaps: []corev1.ConfigMap{pendingConfigMap("cm-a", "v1", "", oneTarget, common.UpgradeStatusPending)},
+			binding:    profileBinding("v2", ""),
+		},
+		{
+			name:       "ignores a finished run",
+			configMaps: []corev1.ConfigMap{pendingConfigMap("cm-a", "v1", "", oneTarget, common.UpgradeStatusCompleted)},
+			binding:    profileBinding("v1", ""),
+		},
+		{
+			name:       "a repeated force-upgrade is a new run",
+			configMaps: []corev1.ConfigMap{pendingConfigMap("cm-a", "v1", "2026-08-27T06:00:00Z", oneTarget, common.UpgradeStatusPending)},
+			binding:    profileBinding("v1", "2026-08-27T07:00:00Z"),
+		},
+		{
+			name:       "resumes when the force-upgrade stamp matches",
+			configMaps: []corev1.ConfigMap{pendingConfigMap("cm-a", "v1", "2026-08-27T06:00:00Z", oneTarget, common.UpgradeStatusPending)},
+			binding:    profileBinding("v1", "2026-08-27T06:00:00Z"),
+			wantFound:  "cm-a",
+		},
+		{
+			name:       "a run without targets cannot be resumed",
+			configMaps: []corev1.ConfigMap{pendingConfigMap("cm-a", "v1", "", "", common.UpgradeStatusPending)},
+			binding:    profileBinding("v1", ""),
+		},
+		{
+			name: "picks the resumable run among several",
+			configMaps: []corev1.ConfigMap{
+				pendingConfigMap("cm-old", "v0", "", oneTarget, common.UpgradeStatusCompleted),
+				pendingConfigMap("cm-b", "v1", "", oneTarget, common.UpgradeStatusPending),
+			},
+			binding:   profileBinding("v1", ""),
+			wantFound: "cm-b",
+		},
+		{
+			name:       "no upgrader ConfigMaps at all",
+			configMaps: nil,
+			binding:    profileBinding("v1", ""),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kc := &stubClient{configMaps: tc.configMaps}
+
+			configMap, targets, err := findPendingUpgrade(context.Background(), kc, tc.binding)
+			if err != nil {
+				t.Fatalf("findPendingUpgrade: %v", err)
+			}
+
+			if tc.wantFound == "" {
+				if configMap != nil {
+					t.Fatalf("got ConfigMap %q, want none", configMap.Name)
+				}
+				return
+			}
+
+			if configMap == nil {
+				t.Fatalf("got no ConfigMap, want %q", tc.wantFound)
+			}
+			if configMap.Name != tc.wantFound {
+				t.Fatalf("got ConfigMap %q, want %q", configMap.Name, tc.wantFound)
+			}
+			if len(targets) != 1 || targets[0] != target("observability", "prom-label-proxy", 2) {
+				t.Fatalf("targets = %+v, want the one recorded on the ConfigMap", targets)
+			}
+		})
+	}
+}
+
+func TestFindPendingUpgradeScopesTheListToTheBinding(t *testing.T) {
+	kc := &stubClient{}
+	if _, _, err := findPendingUpgrade(context.Background(), kc, profileBinding("v1", "")); err != nil {
+		t.Fatalf("findPendingUpgrade: %v", err)
+	}
+
+	options := &client.ListOptions{}
+	for _, opt := range kc.listOpts {
+		opt.ApplyToList(options)
+	}
+	if options.Namespace != "spoke" {
+		t.Errorf("namespace = %q, want %q", options.Namespace, "spoke")
+	}
+	// Without the label selector the controller would sweep every ConfigMap in the
+	// cluster namespace.
+	if options.LabelSelector == nil || !options.LabelSelector.Matches(labels.Set{common.ACEUpgrader: "true"}) {
+		t.Errorf("label selector = %v, want it to select upgrader ConfigMaps", options.LabelSelector)
+	}
+}
+
+type labelSet map[string]string
+
+func (l labelSet) Has(key string) bool   { _, found := l[key]; return found }
+func (l labelSet) Get(key string) string { return l[key] }
+
+func TestFindPendingUpgradeSurfacesErrors(t *testing.T) {
+	t.Run("list error", func(t *testing.T) {
+		kc := &stubClient{listErr: errors.New("boom")}
+		if _, _, err := findPendingUpgrade(context.Background(), kc, profileBinding("v1", "")); err == nil {
+			t.Fatal("expected the list error to surface")
+		}
+	})
+
+	t.Run("malformed targets", func(t *testing.T) {
+		kc := &stubClient{configMaps: []corev1.ConfigMap{pendingConfigMap("cm-a", "v1", "", "{not json", common.UpgradeStatusPending)}}
+		if _, _, err := findPendingUpgrade(context.Background(), kc, profileBinding("v1", "")); err == nil {
+			t.Fatal("expected the unmarshal error to surface")
+		}
+	})
+}

--- a/pkg/cluster_upgrade/upgrader_helper_test.go
+++ b/pkg/cluster_upgrade/upgrader_helper_test.go
@@ -56,7 +56,7 @@ func (c *stubClient) Scheme() *runtime.Scheme {
 	if err := corev1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
-	if err := workv1.AddToScheme(scheme); err != nil {
+	if err := workv1.Install(scheme); err != nil {
 		panic(err)
 	}
 	return scheme
@@ -111,6 +111,11 @@ func (c *stubClient) Patch(_ context.Context, obj client.Object, _ client.Patch,
 	return nil
 }
 
+const (
+	hrNamespace    = "kubeops"
+	testGeneration = 2
+)
+
 func stringValue(name, value string) workv1.FeedbackValue {
 	return workv1.FeedbackValue{Name: name, Value: workv1.FieldValue{Type: workv1.String, String: &value}}
 }
@@ -121,7 +126,7 @@ func intValue(name string, value int64) workv1.FeedbackValue {
 
 // manifestWork builds a ManifestWork whose status reports hrNamespace/hrName with
 // the given feedback. applied controls the Applied condition the work agent sets.
-func manifestWork(name, hrNamespace, hrName string, applied bool, values ...workv1.FeedbackValue) *workv1.ManifestWork {
+func manifestWork(name, hrName string, applied bool, values ...workv1.FeedbackValue) *workv1.ManifestWork {
 	status := metav1.ConditionFalse
 	if applied {
 		status = metav1.ConditionTrue
@@ -142,11 +147,11 @@ func manifestWork(name, hrNamespace, hrName string, applied bool, values ...work
 	}
 }
 
-func readyFeedback(generation int64) []workv1.FeedbackValue {
+func readyFeedback() []workv1.FeedbackValue {
 	return []workv1.FeedbackValue{
 		stringValue(common.HelmReleaseReadyFeedback, string(metav1.ConditionTrue)),
-		intValue(common.HelmReleaseGenerationFeedback, generation),
-		intValue(common.HelmReleaseObservedGenerationFeedback, generation),
+		intValue(common.HelmReleaseGenerationFeedback, testGeneration),
+		intValue(common.HelmReleaseObservedGenerationFeedback, testGeneration),
 	}
 }
 
@@ -154,7 +159,7 @@ func target(mwName, hrName string, minGeneration int64) upgradeTarget {
 	return upgradeTarget{
 		ManifestWorkNamespace: "spoke",
 		ManifestWorkName:      mwName,
-		HelmReleaseNamespace:  "kubeops",
+		HelmReleaseNamespace:  hrNamespace,
 		HelmReleaseName:       hrName,
 		MinGeneration:         minGeneration,
 	}
@@ -190,7 +195,7 @@ func TestEvaluateTargets(t *testing.T) {
 		{
 			name:        "ready target is marked and drops out",
 			targets:     []upgradeTarget{target("observability", "prom-label-proxy", 2)},
-			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "kubeops", "prom-label-proxy", true, readyFeedback(2)...)},
+			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "prom-label-proxy", true, readyFeedback()...)},
 			data:        map[string]string{"prom-label-proxy": string(metav1.ConditionFalse)},
 			wantMarked:  map[string]string{"prom-label-proxy": string(metav1.ConditionTrue)},
 			wantPatches: 1,
@@ -198,7 +203,7 @@ func TestEvaluateTargets(t *testing.T) {
 		{
 			name:        "flux has not observed the new spec yet",
 			targets:     []upgradeTarget{target("observability", "tenant-operator", 2)},
-			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "kubeops", "tenant-operator", true, staleObserved...)},
+			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "tenant-operator", true, staleObserved...)},
 			data:        map[string]string{"tenant-operator": string(metav1.ConditionFalse)},
 			wantPending: []string{"tenant-operator"},
 			wantPatches: 0,
@@ -206,7 +211,7 @@ func TestEvaluateTargets(t *testing.T) {
 		{
 			name:        "not applied on the spoke",
 			targets:     []upgradeTarget{target("observability", "tenant-operator", 2)},
-			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "kubeops", "tenant-operator", false, readyFeedback(2)...)},
+			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "tenant-operator", false, readyFeedback()...)},
 			data:        map[string]string{"tenant-operator": string(metav1.ConditionFalse)},
 			wantPending: []string{"tenant-operator"},
 			wantPatches: 0,
@@ -214,7 +219,7 @@ func TestEvaluateTargets(t *testing.T) {
 		{
 			name:        "already marked ready is not patched again",
 			targets:     []upgradeTarget{target("observability", "prom-label-proxy", 2)},
-			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "kubeops", "prom-label-proxy", true, readyFeedback(2)...)},
+			works:       map[string]*workv1.ManifestWork{"spoke/observability": manifestWork("observability", "prom-label-proxy", true, readyFeedback()...)},
 			data:        map[string]string{"prom-label-proxy": string(metav1.ConditionTrue)},
 			wantPatches: 0,
 		},
@@ -233,8 +238,8 @@ func TestEvaluateTargets(t *testing.T) {
 				target("core", "kube-ui-server", 3),
 			},
 			works: map[string]*workv1.ManifestWork{
-				"spoke/observability": manifestWork("observability", "kubeops", "prom-label-proxy", true, readyFeedback(2)...),
-				"spoke/core":          manifestWork("core", "kubeops", "kube-ui-server", true, readyFeedback(2)...),
+				"spoke/observability": manifestWork("observability", "prom-label-proxy", true, readyFeedback()...),
+				"spoke/core":          manifestWork("core", "kube-ui-server", true, readyFeedback()...),
 			},
 			data:        map[string]string{"prom-label-proxy": string(metav1.ConditionFalse), "kube-ui-server": string(metav1.ConditionFalse)},
 			wantPending: []string{"kube-ui-server"},
@@ -294,7 +299,7 @@ func TestEvaluateTargetsPatchFailureIsReported(t *testing.T) {
 	configMap := upgraderConfigMap(map[string]string{"prom-label-proxy": string(metav1.ConditionFalse)})
 	kc := &stubClient{
 		manifestWorks: map[string]*workv1.ManifestWork{
-			"spoke/observability": manifestWork("observability", "kubeops", "prom-label-proxy", true, readyFeedback(2)...),
+			"spoke/observability": manifestWork("observability", "prom-label-proxy", true, readyFeedback()...),
 		},
 		configMaps: []corev1.ConfigMap{*configMap},
 		patchErr:   errors.New("conflict"),
@@ -445,11 +450,6 @@ func TestFindPendingUpgradeScopesTheListToTheBinding(t *testing.T) {
 		t.Errorf("label selector = %v, want it to select upgrader ConfigMaps", options.LabelSelector)
 	}
 }
-
-type labelSet map[string]string
-
-func (l labelSet) Has(key string) bool   { _, found := l[key]; return found }
-func (l labelSet) Get(key string) string { return l[key] }
 
 func TestFindPendingUpgradeSurfacesErrors(t *testing.T) {
 	t.Run("list error", func(t *testing.T) {

--- a/pkg/cluster_upgrade/upgrader_test.go
+++ b/pkg/cluster_upgrade/upgrader_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright AppsCode Inc. and Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster_upgrade
+
+import (
+	"fmt"
+	"testing"
+
+	fluxhelm "github.com/fluxcd/helm-controller/api/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+	workv1 "open-cluster-management.io/api/work/v1"
+)
+
+// storedManifest builds the manifest as the ManifestWork carries it. The bytes
+// are handed over verbatim, so a case can describe exactly what the API server
+// kept -- pruned nulls included.
+func storedManifest(t *testing.T, spec string) workv1.Manifest {
+	t.Helper()
+	raw := fmt.Sprintf(`{"apiVersion":"helm.toolkit.fluxcd.io/v2","kind":"HelmRelease","metadata":{"name":"prom-label-proxy","namespace":"kubeops"},"spec":%s}`, spec)
+	return workv1.Manifest{RawExtension: runtime.RawExtension{Raw: []byte(raw)}}
+}
+
+func renderedSpec(t *testing.T, spec string) fluxhelm.HelmReleaseSpec {
+	t.Helper()
+	var out fluxhelm.HelmReleaseSpec
+	if err := json.Unmarshal([]byte(spec), &out); err != nil {
+		t.Fatalf("failed to build spec from %s: %v", spec, err)
+	}
+	return out
+}
+
+func TestSpecChanged(t *testing.T) {
+	const pruned = `{"interval":"5m0s","chart":{"spec":{"chart":"prom-label-proxy","version":"v2026.6.2"}},"values":{"infra":{"tls":{"jks":{"password":"s3cr3t"}}}}}`
+
+	cases := []struct {
+		name        string
+		oldManifest string
+		newSpec     string
+		want        bool
+	}{
+		{
+			name:        "identical spec",
+			oldManifest: pruned,
+			newSpec:     pruned,
+		},
+		{
+			// A JSON merge patch drops null-valued keys, so the nulls the chart
+			// renders never reach the stored manifest. Reporting a change here
+			// would bump MinGeneration past a generation the spoke never reaches.
+			name:        "chart renders nulls the stored manifest cannot keep",
+			oldManifest: pruned,
+			newSpec:     `{"interval":"5m0s","chart":{"spec":{"chart":"prom-label-proxy","version":"v2026.6.2"}},"values":{"infra":{"tls":{"jks":{"keystore":null,"password":"s3cr3t","truststore":null}}}},"platform":null}`,
+		},
+		{
+			name:        "nulls nested inside a list",
+			oldManifest: `{"interval":"5m0s","values":{"tenants":[{"name":"a"},{"name":"b"}]}}`,
+			newSpec:     `{"interval":"5m0s","values":{"tenants":[{"name":"a","quota":null},{"name":"b","quota":null}]}}`,
+		},
+		{
+			name:        "stored manifest still carries a null",
+			oldManifest: `{"interval":"5m0s","values":{"infra":{"tls":{"jks":{"keystore":null,"password":"s3cr3t"}}}}}`,
+			newSpec:     `{"interval":"5m0s","values":{"infra":{"tls":{"jks":{"password":"s3cr3t"}}}}}`,
+		},
+		{
+			name:        "chart version moves",
+			oldManifest: pruned,
+			newSpec:     `{"interval":"5m0s","chart":{"spec":{"chart":"prom-label-proxy","version":"v2026.7.10"}},"values":{"infra":{"tls":{"jks":{"password":"s3cr3t"}}}}}`,
+			want:        true,
+		},
+		{
+			name:        "a value changes",
+			oldManifest: pruned,
+			newSpec:     `{"interval":"5m0s","chart":{"spec":{"chart":"prom-label-proxy","version":"v2026.6.2"}},"values":{"infra":{"tls":{"jks":{"password":"rotated"}}}}}`,
+			want:        true,
+		},
+		{
+			name:        "a value is dropped rather than nulled",
+			oldManifest: pruned,
+			newSpec:     `{"interval":"5m0s","chart":{"spec":{"chart":"prom-label-proxy","version":"v2026.6.2"}},"values":{"infra":{"tls":{"jks":{}}}}}`,
+			want:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := specChanged(storedManifest(t, tc.oldManifest), renderedSpec(t, tc.newSpec))
+			if err != nil {
+				t.Fatalf("specChanged returned an error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("specChanged = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Only the spec is compared, so the hub-side noise a typed round trip leaves
+// behind -- an empty status, a null creationTimestamp -- must not read as a
+// change the spoke will act on.
+func TestSpecChangedIgnoresNonSpecNoise(t *testing.T) {
+	const spec = `{"interval":"5m0s","values":{"replicas":1}}`
+	raw := fmt.Sprintf(`{"apiVersion":"helm.toolkit.fluxcd.io/v2","kind":"HelmRelease","metadata":{"name":"prom-label-proxy","namespace":"kubeops","creationTimestamp":null},"spec":%s,"status":{}}`, spec)
+	manifest := workv1.Manifest{RawExtension: runtime.RawExtension{Raw: []byte(raw)}}
+
+	changed, err := specChanged(manifest, renderedSpec(t, spec))
+	if err != nil {
+		t.Fatalf("specChanged returned an error: %v", err)
+	}
+	if changed {
+		t.Error("specChanged = true, want false for a spec that only differs outside .spec")
+	}
+}
+
+func TestSpecChangedRejectsAnUnreadableManifest(t *testing.T) {
+	manifest := workv1.Manifest{RawExtension: runtime.RawExtension{Raw: []byte(`{"spec":`)}}
+	if _, err := specChanged(manifest, fluxhelm.HelmReleaseSpec{}); err == nil {
+		t.Fatal("expected an error for a malformed manifest")
+	}
+}
+
+func TestNewUpgradeTargetBumpsOnlyOnAChange(t *testing.T) {
+	mw := manifestWork("observability", "prom-label-proxy", true, readyFeedback()...)
+	hr := &fluxhelm.HelmRelease{}
+	hr.Name = "prom-label-proxy"
+	hr.Namespace = "kubeops"
+
+	if unchanged := newUpgradeTarget(mw, hr, false); unchanged.MinGeneration != testGeneration {
+		t.Errorf("MinGeneration = %d, want the reported generation %d", unchanged.MinGeneration, testGeneration)
+	}
+	if changed := newUpgradeTarget(mw, hr, true); changed.MinGeneration != testGeneration+1 {
+		t.Errorf("MinGeneration = %d, want %d for a changed spec", changed.MinGeneration, testGeneration+1)
+	}
+}

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -24,6 +24,14 @@ const (
 	ACEUpgraderVersion = "ace.cloud.com/version"
 	UpgradeAnnotation  = "ace.cloud.com/upgradeAt"
 
+	// UpgradeTargetsAnnotation carries the HelmReleases an in-flight upgrade is
+	// waiting on, so a later reconcile can resume the wait instead of re-applying.
+	UpgradeTargetsAnnotation = "profile.k8s.appscode.com/upgrade-targets"
+
+	UpgradeStatusKey       = "status"
+	UpgradeStatusPending   = "pending"
+	UpgradeStatusCompleted = "completed"
+
 	HelmReleaseReadyFeedback              = "Ready"
 	HelmReleaseGenerationFeedback         = "Generation"
 	HelmReleaseObservedGenerationFeedback = "ObservedGeneration"

--- a/pkg/controller/managedclusterprofilebinding_controller.go
+++ b/pkg/controller/managedclusterprofilebinding_controller.go
@@ -103,8 +103,15 @@ func (r *ManagedClusterProfileBindingReconciler) Reconcile(ctx context.Context, 
 	}
 	if r.needsUpgrade(profileBinding) {
 		logger.Info("Triggering cluster upgrade")
-		if err := cluster_upgrade.UpgradeCluster(ctx, profileBinding, profile, r.Client); err != nil {
+		result, err := cluster_upgrade.UpgradeCluster(ctx, profileBinding, profile, r.Client)
+		if err != nil {
 			return reconcile.Result{}, r.setOpscenterFeaturesVersion(ctx, profileBinding, upgradeTime, err)
+		}
+		if !result.IsZero() {
+			// The upgrade is still converging on the spoke. Advancing the observed
+			// version here would make needsUpgrade() false and strand it, so leave
+			// the status alone and come back for the next observation.
+			return result, nil
 		}
 	} else if r.shouldEnableFeatures(profileBinding, profile) {
 		logger.Info("Enabling features")


### PR DESCRIPTION
## Problem

`UpgradeCluster` blocked inside one `Reconcile` call for up to 30 minutes (`waitForHelmReleasesReady`). controller-runtime serializes per object key, so for the whole wait the binding was **deaf to its own events** — including the `ManagedClusterSetProfile` edit an operator makes to fix the very HelmRelease the wait is stuck on.

Observed on a live hub:

```
06:01:12  Start reconciling / Triggering cluster upgrade   (arnob-monitoring)
06:12:41  Enqueuing request arnob-monitoring  x2           <- profile edit, absorbed
          ... no reconcile for 19 more minutes ...
06:31:33  ERROR Reconciler error: timed out after 30m0s waiting for HelmRelease(s)
          to become ready: kubeops/tenant-operator, kubeops/prom-label-proxy
06:31:33  Start reconciling (arnob-monitoring)             <- edit finally runs
```

`MaxConcurrentReconciles: 3` does not help — the limit is per key, not worker starvation.

Same shape caused two more problems: every retry restarted the fake API server and re-rendered the `opscenter-features` chart (118 resources, ~11-25s) before it could observe anything, and each attempt created a fresh `features-upgrader-<rand>` ConfigMap, leaving the previous one behind (one cluster namespace had two, both claiming the same version, with no way for the UI to tell which was authoritative).

## Changes

**Phase split.** `UpgradeCluster` returns `(ctrl.Result, error)` and dispatches:

- `applyUpgrade` — the previous body: fake server, render, create the upgrader ConfigMap, patch the `opscenter-core` HelmRelease and every `featureset.appscode.com/managed` ManifestWork, install feedback rules, compute `MinGeneration`. Then requeues instead of waiting.
- `observeUpgrade` — cached reads only. No fake server, no render.

State needed to resume lives on the upgrader ConfigMap: targets in `profile.k8s.appscode.com/upgrade-targets`, run identity from the existing version label plus the `ace.cloud.com/upgradeAt` annotation, deadline derived from `CreationTimestamp`. A ConfigMap without the annotation (written by an older build) cannot be resumed and falls back to a fresh apply — safe, since every patch is idempotent.

**Status guard.** On a pending requeue the binding controller returns without calling `setOpscenterFeaturesVersion`. Advancing the observed version mid-wait would make `needsUpgrade()` false and strand the upgrade.

**Stale ConfigMap collection.** `createConfigMapInSpokeClusterNamespace` deletes prior upgrader ConfigMaps first, so the UI always has exactly one. `patchConfigMapData` merges annotations rather than assigning.

**Profile chart precedence on the upgrade path.** The upgrade path took the version from `feature.Spec.Chart.Version` (the `opscenter-features` chart's opinion) and never touched the namespace, so pinning or relocating a feature via the profile had no effect during an upgrade. It now applies the same override the non-upgrade path uses in `GetFeatureSetValues`, and carries the resulting chart into `TargetNamespace` / `StorageNamespace` / `Install.CreateNamespace`.

The `status: completed` contract is unchanged: it means the job is done, and success is still read from the per-feature values.

## Behavior changes to review

1. **The chart precedence change has real blast radius.** Profiles that pin versions differing from the shipped chart will now have those pins applied on the next upgrade, across every feature — not just the one being fixed.
2. **A namespace change orphans the old release.** Flux installs into the new namespace and leaves the previous release and its resources behind; there is no cleanup.
3. **ConfigMap collection drops upgrade history** — the previous run's per-feature results are gone once a new upgrade starts.

## Testing

`go build ./...`, `go vet ./pkg/...`, `gofmt` all clean.

`make fmt` / `make build` / `make lint` were **not** run — no Docker available in the authoring environment. Please let CI cover those.

`pkg/cluster_upgrade/upgrader_helper_test.go` covers the observe phase — 18 subtests, all passing:

- `evaluateTargets`: a ready target is marked and drops out; a target flux has not observed yet (generation 2, observedGeneration 1) stays pending despite `Ready=True`; a manifest not applied on the spoke stays pending; an already-marked feature is not patched again; an unreadable ManifestWork keeps its target pending without failing the upgrade; a patch failure is surfaced.
- `findPendingUpgrade`: resumes a pending run for this version; ignores another version, a finished run, and a run whose force-upgrade stamp differs; refuses to resume a run with no targets annotation; picks the resumable run among several; surfaces list and unmarshal errors; and asserts the List stays scoped by namespace *and* the upgrader label.

The stub client embeds `client.Client` unset, so an unexpected call panics rather than silently passing. Mutation-checked: removing the observedGeneration check, dropping the label selector, and removing the "newly became ready" guard each fail the suite.
